### PR TITLE
Fix pyproject dependencies:

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -2,11 +2,11 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "dev", "diskcache-utils", "fastapi-utils", "httpx-utils", "loguru-utils", "msgpack-utils"]
+groups = ["default", "dev", "diskcache-utils", "fastapi-utils", "httpx-utils", "loguru-utils", "msgpack-utils", "all"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:e788ea1614496145cee915947c309a3d814a420e150627671031044d8671fe13"
+content_hash = "sha256:5704cac381005a6934f08f5bc8671570a7a45169184398c2ee7a08bf9e719ab4"
 
 [[package]]
 name = "annotated-types"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,10 @@ authors = [
     { name = "redjax", email = "none@none.com" },
 ]
 dependencies = [
+    "diskcache>=5.6.1",
+    "loguru>=0.7.0",
+    "msgpack>=1.0.5",
+    "httpx>=0.24.1",
 ]
 requires-python = ">=3.11"
 readme = "README.md"
@@ -34,6 +38,15 @@ loguru-utils = [
 msgpack-utils = [
     "msgpack>=1.0.5",
 ]
+all = [
+    "diskcache>=5.6.1",
+    "fastapi>=0.100.0",
+    "uvicorn[standard]>=0.23.0",
+    "loguru>=0.7.0",
+    "httpx>=0.24.1",
+    "msgpack>=1.0.5",
+]
+
 [build-system]
 requires = [
     "pdm-backend",


### PR DESCRIPTION
Add base depdencies to pdm project. Skip adding fastapi & uvicorn due to import time.

Add new group 'all' which installs all dependencies, including fastapi & uvicorn