### PR TITLE
hotfix(fastapi-utils): Add fix_api_docs()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "red_utils"
-version = "0.1.8"
+version = "0.1.10"
 description = "Collection of utility scripts/functions that I use frequently."
 authors = [
     { name = "redjax", email = "none@none.com" },

--- a/red_utils/fastapi_utils/__init__.py
+++ b/red_utils/fastapi_utils/__init__.py
@@ -16,7 +16,13 @@ from .constants import (
     tags_metadata,
 )
 from .dependencies import logging_dependency
-from .operations import add_cors_middleware, add_routers, get_app, update_tags_metadata
+from .operations import (
+    add_cors_middleware,
+    add_routers,
+    get_app,
+    update_tags_metadata,
+    fix_api_docs,
+)
 from .tag_definitions import tags_metadata
 from .uvicorn_override import InterceptHandler, setup_uvicorn_logging
 from .validators import (

--- a/red_utils/fastapi_utils/operations.py
+++ b/red_utils/fastapi_utils/operations.py
@@ -23,6 +23,32 @@ import fastapi
 from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+
+def fix_api_docs(app: FastAPI = None):
+    """Fix error loading /docs when a root_path is set.
+
+    Call after declaring an app with a root_path set, for example:
+        app = FastAPI(root_path="/some/path")
+        fix_api_docs(app)
+
+    When a root_path is declared, the default /docs URL breaks, and returns
+    an error:
+        Fetch error
+        Not Found /api/v1/openapi.json
+    """
+    if not app:
+        raise ValueError("Missing a FastAPI app with a root_path var declared")
+
+    if not isinstance(app, FastAPI):
+        raise TypeError(
+            f"Invalid type for FastAPI app: ({type(app)}). Value must be of type FastAPI."
+        )
+
+    @app.get(app.root_path + "/openapi.json")
+    def custom_swagger_ui_html():
+        return app.openapi()
+
+
 def update_tags_metadata(
     tags_metadata: list = tags_metadata,
     update_metadata: Union[list[dict[str, str]], dict[str, str]] = None,


### PR DESCRIPTION
This was supposed to go out in the last release (v0.1.9) but was overwritten somehow.