### PR TITLE
release(v0.1.13): Hotfix release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "red_utils"
-version = "0.1.12"
+version = "0.1.13"
 description = "Collection of utility scripts/functions that I use frequently."
 authors = [
     { name = "redjax", email = "none@none.com" },


### PR DESCRIPTION
Fix some sloppy code mistakes that were creating import errors.

Re-add code that was somehow removed from fastapi_utils.fix_api_docs()

Bump pyproject release number