### PR TITLE
Add new dependency group "standard."

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -2,11 +2,11 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "dev", "all", "fastapi", "http"]
+groups = ["default", "dev", "all", "fastapi", "http", "standard"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:7d55870ff3fb20af5882177e5d5050db22af3481b3e53d1d190e7cf666bd0851"
+content_hash = "sha256:09c7b7e6217f3e27c0a5c089edb8f75c54479c1df5c79e52faa1303097a2f7b3"
 
 [[package]]
 name = "annotated-types"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "msgpack>=1.0.5",
     "httpx>=0.24.1",
     "arrow>=1.2.3",
-    "sqlalchemy>=2.0.20",
     "pendulum>=2.1.2",
     "rich>=13.5.3",
 ]
@@ -26,6 +25,17 @@ text = "MIT"
 Repository = "https://github.com/redjax/red-utils"
 
 [project.optional-dependencies]
+
+standard = [
+    "diskcache>=5.6.1",
+    "loguru>=0.7.0",
+    "httpx>=0.24.1",
+    "pendulum>=2.1.2",
+    "rich>=13.5.3",
+    "msgpack>=1.0.5",
+    "sqlalchemy>=2.0.21",
+]
+
 all = [
     "diskcache>=5.6.1",
     "fastapi>=0.100.0",
@@ -34,7 +44,9 @@ all = [
     "httpx>=0.24.1",
     "msgpack>=1.0.5",
     "pendulum>=2.1.2",
+    "sqlalchemy>=2.0.21",
 ]
+
 fastapi = [
     "fastapi>=0.103.1",
     "sqlalchemy>=2.0.21",
@@ -44,12 +56,14 @@ fastapi = [
     "uvicorn>=0.23.2",
     "pendulum>=2.1.2",
 ]
+
 http = [
     "httpx>=0.25.0",
     "diskcache>=5.6.3",
     "loguru>=0.7.2",
     "pendulum>=2.1.2",
     "msgpack>=1.0.5",
+    "pendulum>=2.1.2",
 ]
 
 [tool.pdm.dev-dependencies]


### PR DESCRIPTION
Includes standard set of utilities, i.e. SQLAlchemy for database, Diskcache for a cache, loguru for logging, etc.

Add pendulum to all dependency groups. Planning to replace Arrow functions with pendulum

Remove SQLAlchemy from base dependency group