### PR TITLE
Add Loguru sink classes.

### DIFF
--- a/red_utils/ext/loguru_utils/__init__.py
+++ b/red_utils/ext/loguru_utils/__init__.py
@@ -1,7 +1,7 @@
 ## Import default constants
 from __future__ import annotations
 
-from . import constants, operations, sinks, validators
+from . import constants, operations, sinks, validators, enums
 from .constants import (
     LogLevel,
     default_color_fmt,
@@ -13,6 +13,14 @@ from .constants import (
 )
 from .operations import add_sink, init_logger
 from .sinks import (
+    LoguruSinkDefault,
+    LoguruSinkStdErr,
+    LoguruSinkStdOut,
+    LoguruSinkAppFile,
+    LoguruSinkErrFile,
+    LoguruSinkTraceFile,
+)
+from .sinks import (
     default_app_log_file_sink,
     default_error_log_file_sink,
     default_sinks,
@@ -23,3 +31,4 @@ from .sinks import (
     default_trace_log_file_sink,
 )
 from .validators import validate_compression_str, validate_level, validate_logger
+from .enums import EnumDefaultSinks, EnumLogLevels

--- a/red_utils/ext/loguru_utils/enums.py
+++ b/red_utils/ext/loguru_utils/enums.py
@@ -1,0 +1,21 @@
+from enum import Enum
+import sys
+from typing import TextIO
+
+
+class EnumLogLevels(Enum):
+    TRACE: str = "TRACE"
+    DEBUG: str = "DEBUG"
+    INFO: str = "INFO"
+    SUCCESS: str = "SUCCESS"
+    WARNING: str = "WARNING"
+    ERROR: str = "ERROR"
+    CRITICAL: str = "CRITICAL"
+
+
+class EnumDefaultSinks(Enum):
+    STDOUT: TextIO = sys.stdout
+    STDERR: TextIO = sys.stderr
+    APP_FILE: str = "logs/app.log"
+    ERROR_FILE: str = "logs/err.log"
+    TRACE_FILE: str = "logs/trace.log"

--- a/red_utils/ext/loguru_utils/sinks.py
+++ b/red_utils/ext/loguru_utils/sinks.py
@@ -4,6 +4,136 @@ import sys
 
 from .constants import default_color_fmt, default_fmt, default_log_dir
 
+from typing import TextIO, Union, Generic, TypeVar
+from dataclasses import dataclass, field
+
+## Generic type for dataclass classes
+T = TypeVar("T")
+
+
+@dataclass
+class DictMixin:
+    """Mixin class to add "as_dict()" method to classes. Equivalent to .__dict__.
+
+    Add a .as_dict() method to classes that inherit from this mixin. For example,
+    to add .as_dict() method to a parent class, where all children inherit the .as_dict()
+    function, declare parent as:
+
+    @dataclass
+    class Parent(DictMixin):
+        ...
+
+    and call like:
+
+        p = Parent()
+        p_dict = p.as_dict()
+    """
+
+    def as_dict(self: Generic[T]):
+        """Return dict representation of a dataclass instance."""
+        try:
+            return self.__dict__.copy()
+
+        except Exception as exc:
+            raise Exception(
+                f"Unhandled exception converting class instance to dict. Details: {exc}"
+            )
+
+
+@dataclass
+class LoguruSinkBase(DictMixin):
+    """Base Loguru sink class.
+
+    Define common options for children to inherit from.
+    """
+
+    sink: Union[str, TextIO] = field(default=sys.stdout)
+    format: str = field(default=default_fmt)
+    level: str = field(default="INFO")
+    colorize: bool = field(default=False)
+
+    def __post_init__(self):
+        self.level = self.level.upper()
+
+
+@dataclass
+class LoguruSinkDefault(LoguruSinkBase):
+    """Default Loguru sink. Defaults to colorized, formatted stdout, level=INFO.
+
+    Use this class as a starting point to create customized Loguru sinks. Create a new class
+    by inheriting from this one:
+
+    my_loguru_sink = LoguruSinkDefault(sink=...,level=..., colorize=True)
+    """
+
+    pass
+
+
+@dataclass
+class LoguruSinkStdOut(LoguruSinkBase, DictMixin):
+    format: str = field(default=default_color_fmt)
+    colorize: bool = field(default=True)
+
+
+@dataclass
+class LoguruSinkStdErr(LoguruSinkBase):
+    sink: Union[str, TextIO] = field(default=sys.stderr)
+    format: str = field(default=default_color_fmt)
+    colorize: bool = field(default=True)
+
+
+@dataclass
+class LoguruSinkFileBase(DictMixin):
+    """Base class for file sinks."""
+
+    sink: Union[str, TextIO] = field(default=f"{default_log_dir}/app.log")
+    colorize: bool = field(default=True)
+    retention: Union[str, int] = field(default=3)
+    rotation: str = field(default="5 MB")
+    format: str = field(default=default_fmt)
+    level: str = field(default="DEBUG")
+    enqueue: bool = field(default=True)
+
+
+@dataclass
+class LoguruSinkFileDefault(LoguruSinkFileBase):
+    """Default Loguru file sink. Defaults to app.log, level=DEBUG.
+
+    Use this class as a starting point to create customized Loguru file sinks. Create a new class
+    by inheriting from this one:
+
+    my_loguru_file_sink = LoguruSinkFileDefault(sink=...,level=..., colorize=True)
+    """
+
+    pass
+
+
+@dataclass
+class LoguruSinkAppFile(LoguruSinkFileBase, DictMixin):
+    """Sink class for app.log file."""
+
+    pass
+
+
+@dataclass
+class LoguruSinkErrFile(LoguruSinkFileBase):
+    """Sink class for error.log file."""
+
+    sink: Union[str, TextIO] = field(default=f"{default_log_dir}/error.log")
+    level: str = field(default="ERROR")
+
+
+@dataclass
+class LoguruSinkTraceFile(LoguruSinkFileBase):
+    """Sink class for trace.log file."""
+
+    sink: Union[str, TextIO] = field(default=f"{default_log_dir}/trace.log")
+    level: str = field(default="TRACE")
+    filter: str = field(default="TRACE")
+    backtrace: bool = field(default=True)
+    diagnose: bool = field(default=True)
+
+
 ## stderr, no color
 default_stderr_sink: dict = {
     "sink": sys.stderr,


### PR DESCRIPTION
Classes all have a .as_dict() method to convert to a dict for the init_logger function.

Included classes define defaults I frequently use. There are also "default" classes that can be used as inheritance bases for customized sink classes.