### PR TITLE
Revert "chore(deps-dev): Bump urllib3 from 2.0.5 to 2.0.7 (#280)"

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -60,5 +60,5 @@ tomlkit==0.12.1
 truststore==0.8.0
 typing-extensions==4.8.0
 unearth==0.11.0
-urllib3==2.0.7
+urllib3==2.0.5
 virtualenv==20.24.5


### PR DESCRIPTION
This reverts commit 532aa8b547ed9f6e3b64689fcc6379719a14945f.

Updating urllib with dependabot broke the PDM project. Revert change to update manually