### PR TITLE
release (v0.2.19): Improve httpx_utils, do cleanup.

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "dev", "all", "fastapi", "http", "standard", "arrow", "data", "dataframes", "ci", "docs"]
+groups = ["default", "dev", "all", "fastapi", "http", "standard", "data", "dataframes", "ci", "docs"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
 content_hash = "sha256:16e62e08ac6a775b1da90ae24001fb82d45130bf7f9bbd554383840e09580d24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "red_utils"
-version = "0.2.18"
+version = "0.2.19"
 description = "Collection of utility scripts/functions that I use frequently."
 authors = [
     { name = "redjax", email = "none@none.com" },
@@ -64,9 +64,22 @@ http = [
     "hishel>=0.0.26",
     "chardet>=5.2.0",
 ]
-data = ["ipykernel>=6.28.0", "pandas>=2.1.4", "fastparquet>=2023.10.1"]
-dataframes = ["pandas>=2.1.4", "fastparquet>=2023.10.1", "pyarrow>=15.0.0"]
-ci = ["ruff>=0.1.13", "black>=23.12.1", "pytest>=7.4.4", "nox>=2023.4.22"]
+data = [
+    "ipykernel>=6.28.0",
+    "pandas>=2.1.4",
+    "fastparquet>=2023.10.1",
+]
+dataframes = [
+    "pandas>=2.1.4",
+    "fastparquet>=2023.10.1",
+    "pyarrow>=15.0.0",
+]
+ci = [
+    "ruff>=0.1.13",
+    "black>=23.12.1",
+    "pytest>=7.4.4",
+    "nox>=2023.4.22",
+]
 docs = [
     "pygments>=2.17.2",
     "mkdocs>=1.5.3",
@@ -123,15 +136,12 @@ shell = "pdm export -G ci --no-default -o requirements.ci.txt --without-hashes"
 [tool.pdm.scripts.export-docs]
 shell = "pdm export -G docs --no-default -o docs/requirements.txt --without-hashes"
 
-## BUMP.x.x
 [tool.pdm.scripts.create-major-release]
 shell = "pdm bump major && pdm bump tag && pdm lock && pdm build && git push --tags"
 
-## x.BUMP.x
 [tool.pdm.scripts.create-minor-release]
 shell = "pdm bump minor && pdm bump tag && pdm lock && pdm build && git push --tags"
 
-## x.x.BUMP
 [tool.pdm.scripts.create-micro-release]
 shell = "pdm bump micro && pdm bump tag && pdm lock && pdm build && git push --tags"
 


### PR DESCRIPTION
(Release version does not match branch name  due to 2 dev environment releases that were not created as github releases...woops)

Remove arrow dependency & code. Red-utils now fully uses pendulum for 3rd party datetime operations.

Improve development environment.

Cleanup dendencies list.

Add/improve tests.